### PR TITLE
Update dbw_node.py

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -63,6 +63,7 @@ class DBWNode(object):
         self.previous_loop_time = rospy.get_rostime()
         self.previous_debug_time = rospy.get_rostime()
 
+        # Update PID Values - Matt
         self.throttle_pid = pid.PID(kp=0.5, ki=0.0, kd=0.0, mn=decel_limit, mx=0.5 * accel_limit)
         self.brake_pid = pid.PID(kp=250.0, ki=0.0, kd=2.5, mn=brake_deadband, mx=5000)
         self.steering_pid = pid.PID(kp=0.5, ki=0.0, kd=1.0, mn=-max_steer_angle, mx=max_steer_angle)

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -63,9 +63,9 @@ class DBWNode(object):
         self.previous_loop_time = rospy.get_rostime()
         self.previous_debug_time = rospy.get_rostime()
 
-        self.throttle_pid = pid.PID(kp=0.2, ki=0.005, kd=0.1, mn=decel_limit, mx=0.5 * accel_limit)
-        self.brake_pid = pid.PID(kp=100.0, ki=0.001, kd=0.1, mn=brake_deadband, mx=2000)
-        self.steering_pid = pid.PID(kp=1.0, ki=0.001, kd=0.5, mn=-max_steer_angle, mx=max_steer_angle)
+        self.throttle_pid = pid.PID(kp=0.5, ki=0.0, kd=0.0, mn=decel_limit, mx=0.5 * accel_limit)
+        self.brake_pid = pid.PID(kp=250.0, ki=0.0, kd=2.5, mn=brake_deadband, mx=5000)
+        self.steering_pid = pid.PID(kp=0.5, ki=0.0, kd=1.0, mn=-max_steer_angle, mx=max_steer_angle)
 
         self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
                                          SteeringCmd, queue_size=1)

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -63,7 +63,6 @@ class DBWNode(object):
         self.previous_loop_time = rospy.get_rostime()
         self.previous_debug_time = rospy.get_rostime()
 
-        # Update PID Values - Matt
         self.throttle_pid = pid.PID(kp=0.5, ki=0.0, kd=0.0, mn=decel_limit, mx=0.5 * accel_limit)
         self.brake_pid = pid.PID(kp=250.0, ki=0.0, kd=2.5, mn=brake_deadband, mx=5000)
         self.steering_pid = pid.PID(kp=0.5, ki=0.0, kd=1.0, mn=-max_steer_angle, mx=max_steer_angle)


### PR DESCRIPTION
Update PID values in dbw_node.py

I updated the PID values to try and reduce oscillation following the waypoints and overshoot at the stop lights. The model tended to perform well at both low speed (ref 9.0) and high speed (ref 40.0). 
 
- Change throttle controller PID values to kp = 0.5, kd, ki = 0.0. The integral and derivative controls are not needed as the low speed does not result in oscillation or instability.

- Change brake controller PID values to kp = 250.0, kd = 2.5, and ki = 0.0. The brake event relates to high-speed dynamics, therefore the derivative control can be used to estimate future positions and correct. This seems to correct the overshoot at stop lights. The integral control tends to create an overshoot condition, therefore it was removed. 

- Change steering control to kp = 0.5, ki = 0.0, kd = 1.0. The integral control was removed as it reduced oscillations when the car was tested at high speed. The steering aspect was minimally improved at low speed.